### PR TITLE
add support for new ethereal trees

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -352,6 +352,9 @@ if minetest.get_modpath("ethereal") and minetest.global_exists("ethereal") then
 	lumberjack.register_tree("ethereal:banana_trunk", "ethereal:banana_tree_sapling", 1, 3)
 	lumberjack.register_tree("ethereal:willow_trunk", "ethereal:willow_sapling", 4, 3)
 	lumberjack.register_tree("ethereal:frost_tree", "ethereal:frost_tree_sapling", 1, 3)
+	lumberjack.register_tree("ethereal:sakura_trunk", "ethereal:sakura_sapling", 4, 3)
+	lumberjack.register_tree("ethereal:redwood_trunk", "ethereal:redwood_sapling", 6, 3)
+	lumberjack.register_tree("ethereal:yellow_trunk", "ethereal:yellow_tree_sapling", 3, 3)
 end
 
 if minetest.get_modpath("moretrees") and minetest.global_exists("moretrees") then

--- a/init.lua
+++ b/init.lua
@@ -353,7 +353,6 @@ if minetest.get_modpath("ethereal") and minetest.global_exists("ethereal") then
 	lumberjack.register_tree("ethereal:willow_trunk", "ethereal:willow_sapling", 4, 3)
 	lumberjack.register_tree("ethereal:frost_tree", "ethereal:frost_tree_sapling", 1, 3)
 	lumberjack.register_tree("ethereal:sakura_trunk", "ethereal:sakura_sapling", 4, 3)
-	lumberjack.register_tree("ethereal:redwood_trunk", "ethereal:redwood_sapling", 6, 3)
 	lumberjack.register_tree("ethereal:yellow_trunk", "ethereal:yellow_tree_sapling", 3, 3)
 end
 


### PR DESCRIPTION
I found that lumberjack doesn't fully work with the current version of ethereal_ng, so I've looked through the source and added support for the three new relevant trees I could find:

- sakura tree (fairly unproblematic, they don't have thick trunks, but their branches extend fairly far out, a radius of 4 has worked perfectly for me so far)
- "yellow tree", could also be called healing tree or golden apple tree I guess (has some extending branches, but I haven't found one where a radius of 3 isn't enough yet)
- redwood tree - this one is really problematic. These trees are *massive*, and by massive I mean their trunks are usually 3-4 blocks in diameter, sometimes starting at 6 near the roots, *and* they have branches extending beyond that. And then the fun part: Even with a radius of 6, the whole tree sometimes isn't destroyed, *but* it creates inventory stack overflows (with a maximum stack size of 99, I managed to get stacks of 515 using this). I'm not sure which way to go with that - if that's just too unreasonable, I can just remove the line adding the redwood tree because it just won't work right anyways. (And I also need to report a bug to minetest because that inventory stack overflow needs to be fixed there)

There's also a bamboo tree, but that one already does the "lumberjack" thing itself, and a scorched tree, which logically you should be able to fell, but there's no sapling for it since it's no specific tree, so I'm not sure how to go about that one.