### PR TITLE
Allow to use screwdriver

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -283,6 +283,10 @@ local function can_dig(pos, digger)
 	if is_lumberjack(digger, tree_points, sapl_points) then
 		if chopper_tool(digger) then
 			return true
+		-- Screwdriver
+		elseif node.param1 ~= 0 and
+			digger:get_wielded_item():get_name() == "screwdriver:screwdriver"
+			then return true
 		else
 			minetest.chat_send_player(name, S("[Lumberjack Mod] You are using the wrong tool"))
 			return false


### PR DESCRIPTION
With this first commit one can use screwdriver on trees when they are placed by player

I don't know if there are any other tools that require such passthrough
I didn't test if screwdriver works before gaining lumberjack points, but from what I see it should. Still test is TODO